### PR TITLE
Handle running `add` in a subdirectory

### DIFF
--- a/internal/pkg/cli/add.go
+++ b/internal/pkg/cli/add.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/tentwentyfive/envosaurus/internal/pkg/specs"
-	"gopkg.in/src-d/go-git.v4"
 )
 
 var addCmd = &cobra.Command{
@@ -15,39 +14,17 @@ var addCmd = &cobra.Command{
 	Short: "Add a repository",
 	Long:  `Add the repository in the current directory to your config`,
 	Run: func(cmd *cobra.Command, args []string) {
-		repo, err := git.PlainOpenWithOptions(".", &git.PlainOpenOptions{DetectDotGit: true})
+		projectSpec, err := specs.RepoFromPath(".")
 		if err != nil {
-			fmt.Println("Error determining repo root")
 			fmt.Println(err)
 			os.Exit(1)
 		}
 
-		remotes, err := repo.Remotes()
+		root, err := projectSpec.Git.RepoRoot()
 		if err != nil {
-			fmt.Println("Unable to list remotes")
 			fmt.Println(err)
 			os.Exit(1)
 		}
-
-		url := ""
-		for _, remote := range remotes {
-			config := remote.Config()
-			if config.Name == "origin" {
-				url = config.URLs[0]
-			}
-		}
-
-		worktree, err := repo.Worktree()
-		if err != nil {
-			fmt.Println("Unable to determine repository path")
-			fmt.Println(err)
-			os.Exit(1)
-		}
-		root := worktree.Filesystem.Root()
-		name := filepath.Base(root)
-
-		gitSpec := specs.GitSpec{Clone: url}
-		projectSpec := specs.ProjectSpec{Name: name, Git: &gitSpec}
 
 		var projects specs.ProjectsSpec
 
@@ -74,7 +51,7 @@ var addCmd = &cobra.Command{
 			fmt.Println(err)
 			os.Exit(1)
 		}
-		fmt.Printf("%s written to %s\n", name, repoConfig)
+		fmt.Printf("%s written to %s\n", projectSpec.Name, repoConfig)
 	},
 }
 

--- a/internal/pkg/cli/add.go
+++ b/internal/pkg/cli/add.go
@@ -15,7 +15,7 @@ var addCmd = &cobra.Command{
 	Short: "Add a repository",
 	Long:  `Add the repository in the current directory to your config`,
 	Run: func(cmd *cobra.Command, args []string) {
-		repo, err := git.PlainOpen(".")
+		repo, err := git.PlainOpenWithOptions(".", &git.PlainOpenOptions{DetectDotGit: true})
 		if err != nil {
 			fmt.Println("Error determining repo root")
 			fmt.Println(err)
@@ -37,13 +37,14 @@ var addCmd = &cobra.Command{
 			}
 		}
 
-		absPath, err := filepath.Abs(".")
+		worktree, err := repo.Worktree()
 		if err != nil {
-			fmt.Println("Unable to determine absolute path")
+			fmt.Println("Unable to determine repository path")
 			fmt.Println(err)
 			os.Exit(1)
 		}
-		name := filepath.Base(absPath)
+		root := worktree.Filesystem.Root()
+		name := filepath.Base(root)
 
 		gitSpec := specs.GitSpec{Clone: url}
 		projectSpec := specs.ProjectSpec{Name: name, Git: &gitSpec}
@@ -58,7 +59,7 @@ var addCmd = &cobra.Command{
 			}
 		} else {
 			// by default use the parent directory of the project being added
-			projects.RootDirectory = filepath.Dir(absPath)
+			projects.RootDirectory = filepath.Dir(root)
 		}
 
 		if projects.Contains(&projectSpec) {

--- a/internal/pkg/specs/specs.go
+++ b/internal/pkg/specs/specs.go
@@ -2,8 +2,12 @@ package specs
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
+
+	"gopkg.in/src-d/go-git.v4"
 )
 
 // ProjectsSpec describes a list of projects
@@ -15,6 +19,8 @@ type ProjectsSpec struct {
 // GitSpec describes a git repo
 type GitSpec struct {
 	Clone string `json:"clone"`
+
+	repo *git.Repository
 }
 
 // ProjectSpec describes a single project
@@ -64,4 +70,48 @@ func (projects *ProjectsSpec) Contains(projectSpec *ProjectSpec) bool {
 		}
 	}
 	return false
+}
+
+// RepoFromPath returns a ProjectSpec from a repo at the given path
+func RepoFromPath(path string) (ProjectSpec, error) {
+	repo, err := git.PlainOpenWithOptions(".", &git.PlainOpenOptions{DetectDotGit: true})
+	if err != nil {
+		wrappedError := fmt.Errorf("Unable find a repository: %w", err)
+		return ProjectSpec{Git: &GitSpec{repo: repo}}, wrappedError
+	}
+
+	remotes, err := repo.Remotes()
+	if err != nil {
+		wrappedError := fmt.Errorf("Unable to determine remotes: %w", err)
+		return ProjectSpec{Git: &GitSpec{repo: repo}}, wrappedError
+	}
+
+	url := ""
+	for _, remote := range remotes {
+		config := remote.Config()
+		if config.Name == "origin" {
+			url = config.URLs[0]
+		}
+	}
+
+	gitSpec := GitSpec{Clone: url, repo: repo}
+	root, err := gitSpec.RepoRoot()
+	if err != nil {
+		return ProjectSpec{Git: &gitSpec}, err
+	}
+
+	name := filepath.Base(root)
+	return ProjectSpec{Name: name, Git: &gitSpec}, nil
+}
+
+// RepoRoot returns the root path of the repository
+func (gitSpec *GitSpec) RepoRoot() (string, error) {
+	// we already know we can get the worktree
+	worktree, err := gitSpec.repo.Worktree()
+	if err != nil {
+		wrappedError := fmt.Errorf("Unable to determine repository path: %w", err)
+		return "", wrappedError
+	}
+
+	return worktree.Filesystem.Root(), nil
 }

--- a/internal/pkg/specs/specs.go
+++ b/internal/pkg/specs/specs.go
@@ -74,7 +74,7 @@ func (projects *ProjectsSpec) Contains(projectSpec *ProjectSpec) bool {
 
 // RepoFromPath returns a ProjectSpec from a repo at the given path
 func RepoFromPath(path string) (ProjectSpec, error) {
-	repo, err := git.PlainOpenWithOptions(".", &git.PlainOpenOptions{DetectDotGit: true})
+	repo, err := git.PlainOpenWithOptions(path, &git.PlainOpenOptions{DetectDotGit: true})
 	if err != nil {
 		wrappedError := fmt.Errorf("Unable find a repository: %w", err)
 		return ProjectSpec{Git: &GitSpec{repo: repo}}, wrappedError

--- a/internal/pkg/specs/specs_test.go
+++ b/internal/pkg/specs/specs_test.go
@@ -2,6 +2,7 @@ package specs
 
 import (
 	"encoding/json"
+	"os"
 	"reflect"
 	"testing"
 )
@@ -41,5 +42,40 @@ func TestLoadProjects(t *testing.T) {
 
 	if !reflect.DeepEqual(projects, expect) {
 		t.Error("Expected ", expect, "got ", projects)
+	}
+}
+
+func TestDetermineRepo(t *testing.T) {
+	project, err := RepoFromPath(".")
+	if err != nil {
+		t.Error("Unexpected error ", err)
+	}
+
+	if project.Name != "envosaurus" {
+		t.Error("Unexpected name ", project.Name)
+	}
+
+	if project.Git.Clone != "git@github.com:tentwentyfive/envosaurus" {
+		t.Error("Unexpected remote ", project.Git.Clone)
+	}
+}
+
+func TestDetermineRepoInSubdirectory(t *testing.T) {
+	path, err := os.Getwd()
+	if err != nil {
+		t.Error("Couldn't get working directory ", err)
+	}
+
+	project, err := RepoFromPath(path + "/internal/pkg/specs")
+	if err != nil {
+		t.Error("Unexpected error ", err)
+	}
+
+	if project.Name != "envosaurus" {
+		t.Error("Unexpected name ", project.Name)
+	}
+
+	if project.Git.Clone != "git@github.com:tentwentyfive/envosaurus" {
+		t.Error("Unexpected remote ", project.Git.Clone)
 	}
 }

--- a/internal/pkg/specs/specs_test.go
+++ b/internal/pkg/specs/specs_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -55,7 +56,7 @@ func TestDetermineRepo(t *testing.T) {
 		t.Error("Unexpected name ", project.Name)
 	}
 
-	if project.Git.Clone != "git@github.com:tentwentyfive/envosaurus" {
+	if !strings.HasSuffix(project.Git.Clone, "tentwentyfive/envosaurus") {
 		t.Error("Unexpected remote ", project.Git.Clone)
 	}
 }
@@ -75,7 +76,7 @@ func TestDetermineRepoInSubdirectory(t *testing.T) {
 		t.Error("Unexpected name ", project.Name)
 	}
 
-	if project.Git.Clone != "git@github.com:tentwentyfive/envosaurus" {
+	if !strings.HasSuffix(project.Git.Clone, "tentwentyfive/envosaurus") {
 		t.Error("Unexpected remote ", project.Git.Clone)
 	}
 }


### PR DESCRIPTION
This seems to be relatively common behavior for git-ish tools - i.e., they recursively search parent directories until they find the `.git` directory.

In the process I did some refactoring.  I'm trying to move code out of the cli package to make it more testable.  I continue to have no idea what I'm doing.