### PR TITLE
Switch ProjectSpec.Git to a value

### DIFF
--- a/internal/pkg/specs/specs.go
+++ b/internal/pkg/specs/specs.go
@@ -25,8 +25,8 @@ type GitSpec struct {
 
 // ProjectSpec describes a single project
 type ProjectSpec struct {
-	Name string   `json:"name"`
-	Git  *GitSpec `json:"git,omitempty"`
+	Name string  `json:"name"`
+	Git  GitSpec `json:"git,omitempty"`
 }
 
 // RepoFileIsReadable check if the file exists and is readable
@@ -77,13 +77,13 @@ func RepoFromPath(path string) (ProjectSpec, error) {
 	repo, err := git.PlainOpenWithOptions(path, &git.PlainOpenOptions{DetectDotGit: true})
 	if err != nil {
 		wrappedError := fmt.Errorf("Unable find a repository: %w", err)
-		return ProjectSpec{Git: &GitSpec{repo: repo}}, wrappedError
+		return ProjectSpec{Git: GitSpec{repo: repo}}, wrappedError
 	}
 
 	remotes, err := repo.Remotes()
 	if err != nil {
 		wrappedError := fmt.Errorf("Unable to determine remotes: %w", err)
-		return ProjectSpec{Git: &GitSpec{repo: repo}}, wrappedError
+		return ProjectSpec{Git: GitSpec{repo: repo}}, wrappedError
 	}
 
 	url := ""
@@ -97,11 +97,11 @@ func RepoFromPath(path string) (ProjectSpec, error) {
 	gitSpec := GitSpec{Clone: url, repo: repo}
 	root, err := gitSpec.RepoRoot()
 	if err != nil {
-		return ProjectSpec{Git: &gitSpec}, err
+		return ProjectSpec{Git: gitSpec}, err
 	}
 
 	name := filepath.Base(root)
-	return ProjectSpec{Name: name, Git: &gitSpec}, nil
+	return ProjectSpec{Name: name, Git: gitSpec}, nil
 }
 
 // RepoRoot returns the root path of the repository

--- a/internal/pkg/specs/specs_test.go
+++ b/internal/pkg/specs/specs_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestUnMarshallProject(t *testing.T) {
 	git := GitSpec{Clone: "foo"}
-	var p = []ProjectSpec{{Name: "fred", Git: nil}, {Name: "wilma", Git: &git}}
+	var p = []ProjectSpec{{Name: "fred", Git: GitSpec{}}, {Name: "wilma", Git: git}}
 	var g []ProjectSpec
 	b := `[{"name": "fred"}, {"name": "wilma", "git": {"clone": "foo"}}]`
 	json.Unmarshal([]byte(b), &g)
@@ -35,9 +35,9 @@ func TestLoadProjects(t *testing.T) {
 	expect := ProjectsSpec{
 		RootDirectory: "${HOME}/envosrc",
 		Projects: []ProjectSpec{
-			{Name: "KafkaEx", Git: &kafkaExGit},
-			{Name: "Kayrock", Git: &kayrockGit},
-			{Name: "KafkaExExamples", Git: &kafkaExExamplesGit},
+			{Name: "KafkaEx", Git: kafkaExGit},
+			{Name: "Kayrock", Git: kayrockGit},
+			{Name: "KafkaExExamples", Git: kafkaExExamplesGit},
 		},
 	}
 


### PR DESCRIPTION
I'm still learning go but applying what I know from C++ it's usually
best to use a value unless a pointer is necessary.